### PR TITLE
Inverted A/B button and fixed a typo

### DIFF
--- a/Src/Emulator.cpp
+++ b/Src/Emulator.cpp
@@ -956,7 +956,7 @@ namespace Emulator {
         }
     }
 
-    void RestButtonMapping() {
+    void ResetButtonMapping() {
         for (int i = 0; i < buttonCount; ++i) {
             buttonMapping[i].Buttons[0].InputDevice = DeviceGamepad;
             buttonMapping[i].Buttons[0].IsSet = true;
@@ -985,9 +985,9 @@ namespace Emulator {
 
         // touch controller mapping
         buttonMapping[0].Buttons[1].InputDevice = DeviceRightTouch;
-        buttonMapping[0].Buttons[1].Button = EmuButton_B;
+        buttonMapping[0].Buttons[1].Button = EmuButton_A;
         buttonMapping[1].Buttons[1].InputDevice = DeviceRightTouch;
-        buttonMapping[1].Buttons[1].Button = EmuButton_A;
+        buttonMapping[1].Buttons[1].Button = EmuButton_B;
         buttonMapping[2].Buttons[1].InputDevice = DeviceRightTouch;
         buttonMapping[2].Buttons[1].Button = EmuButton_Trigger;
         buttonMapping[3].Buttons[1].InputDevice = DeviceLeftTouch;


### PR DESCRIPTION
I think on previous request the issue might have been with an extra Emulator.cpp files I had copied in the root of the repository by mistake.

As long as there are no errors this time and you accept the changes, do note that the typo pertains line 959:

void RestButtonMapping() {

which I changed to:

void ResetButtonMapping() {

but since it's referenced in the FrontendGO repository as well, accepting this commit without accepting that one as well will prevent the project from compiling correctly